### PR TITLE
feat: Add meta-llama/Llama-Guard-4-12B model

### DIFF
--- a/app.py
+++ b/app.py
@@ -38,6 +38,13 @@ AVAILABLE_MODELS = {
         "description": "DeepSeek 70B distilled model",
         "temperature_range": (0.0, 1.0),
         "default_temperature": 0.3
+    },
+    "Llama-Guard-4-12B": {
+        "name": "meta-llama/Llama-Guard-4-12B",
+        "context_length": 131072,
+        "description": "Meta Llama Guard 4 12B model - specialized for moderation and safety tasks.",
+        "temperature_range": (0.0, 1.0),
+        "default_temperature": 0.2
     }
 }
 


### PR DESCRIPTION
Adds support for the meta-llama/Llama-Guard-4-12B model from Groq.

I made the following changes:
- Added 'Llama-Guard-4-12B' to the `AVAILABLE_MODELS` dictionary in `app.py`.
- Configuration includes:
    - Groq model name: 'meta-llama/Llama-Guard-4-12B'
    - Context length: 131072 tokens
    - Default temperature: 0.2
    - Description: "Meta Llama Guard 4 12B model - specialized for moderation and safety tasks."

The model is now available for selection in the application's UI. Manual testing steps have been outlined to verify its integration.